### PR TITLE
Use openssh from runtime

### DIFF
--- a/com.syntevo.SmartGit.json
+++ b/com.syntevo.SmartGit.json
@@ -51,6 +51,10 @@
           "url": "https://github.com/git-lfs/git-lfs/releases/download/v2.8.0/git-lfs-linux-amd64-v2.8.0.tar.gz"
         }
       ]
+    },
+      "name": "openssh",
+        "buildsystem": "simple",
+        "build-commands": ["install -D -m0755 -t /app/bin/ $(which ssh)"]
     }, {
       "name": "smartgit",
       "buildsystem": "simple",

--- a/com.syntevo.SmartGit.json
+++ b/com.syntevo.SmartGit.json
@@ -51,7 +51,7 @@
           "url": "https://github.com/git-lfs/git-lfs/releases/download/v2.8.0/git-lfs-linux-amd64-v2.8.0.tar.gz"
         }
       ]
-    },
+    }, {
       "name": "openssh",
         "buildsystem": "simple",
         "build-commands": ["install -D -m0755 -t /app/bin/ $(which ssh)"]

--- a/com.syntevo.SmartGit.json
+++ b/com.syntevo.SmartGit.json
@@ -52,18 +52,6 @@
         }
       ]
     }, {
-      "name": "openssh",
-      "config-opts": ["--without-pie"],
-      "no-make-install": true,
-      "post-install": ["install -D -m0755 -t /app/bin/ ssh"],
-      "sources": [
-        {
-          "type": "archive",
-          "sha256": "bd943879e69498e8031eb6b7f44d08cdc37d59a7ab689aa0b437320c3481fd68",
-          "url": "https://cloudflare.cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-8.0p1.tar.gz"
-        }
-      ]
-    }, {
       "name": "smartgit",
       "buildsystem": "simple",
       "build-commands": [


### PR DESCRIPTION
openssh is available in runtime since freedesktop 19.08 and there is no need to bundle it.