### PR TITLE
SmartGit release 20.2.4

### DIFF
--- a/com.syntevo.SmartGit.metainfo.xml
+++ b/com.syntevo.SmartGit.metainfo.xml
@@ -37,6 +37,6 @@
   <update_contact>info@syntevo.com</update_contact>
   <content_rating type="oars-1.1" />
   <releases>
-    <release date="2021-02-15" version="20.2.3" />
+    <release date="2021-03-08" version="20.2.4" />
   </releases>
 </component>

--- a/com.syntevo.SmartGit.yml
+++ b/com.syntevo.SmartGit.yml
@@ -81,9 +81,9 @@ modules:
         filename: smartgit.tar.gz
         only-arches:
           - x86_64
-        sha256: 2c04d45a09999b03d4cc8f3f8f4588d506efa8954379de2f08e41ac6aa7d4f57
-        size: 124018109
-        url: https://www.syntevo.com/downloads/smartgit/smartgit-linux-20_2_3.tar.gz
+        sha256: 649dcb8d4957fd7d0c9a7ed2104115cfbfc0a14be4d4d6b63a8bb2e2579055c5
+        size: 124018866
+        url: https://www.syntevo.com/downloads/smartgit/smartgit-linux-20_2_4.tar.gz
       - type: file
         path: com.syntevo.SmartGit.metainfo.xml
       - type: file


### PR DESCRIPTION
```shell
==> syntevo SmartGit
Link: https://www.syntevo.com/downloads/smartgit/smartgit-linux-20_2_4.tar.gz
Checksum: 649dcb8d4957fd7d0c9a7ed2104115cfbfc0a14be4d4d6b63a8bb2e2579055c5
Size: 124018866
Version: 20.2.4
Date: 2021-03-08
Upgrade needed! Flatpak version: 20.2.3, released version: 20.2.4
```