### PR TITLE
Add permission to talk to FileManager1 over DBus

### DIFF
--- a/com.syntevo.SmartGit.yaml
+++ b/com.syntevo.SmartGit.yaml
@@ -18,6 +18,7 @@ finish-args:
   - --socket=ssh-auth
   - --socket=x11
   - --talk-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.FileManager1
 modules:
   - name: smartgit
     build-commands:


### PR DESCRIPTION
For revelation to work properly inside the flatpak, SmartGit needs to send messages to org.freedesktop.FileManager1.

Note that this does not fix all issues regarding reveleation, as the method used to send those messages (using dbus-send) is not compatible with the way flatpak proxies fire-and-forget calls. This will be fixed in SmartGit in an upcoming release.